### PR TITLE
Increase axios http request max body length

### DIFF
--- a/fb_reels_publishing_api_sample/index.js
+++ b/fb_reels_publishing_api_sample/index.js
@@ -171,11 +171,15 @@ app.post("/uploadReels", function (req, res) {
 
                 // upload video
                 const uploadBinaryUri = `https://rupload.facebook.com/video-upload/v13.0/${videoId}`;
-                const uploadBinaryResponse = await axios.post(uploadBinaryUri, data, {
+                const uploadBinaryResponse = await axios({
+                    method: 'post',
+                    url: uploadBinaryUri,
+                    data: data,
+                    maxBodyLength: Infinity,
                     headers: {
                         Authorization: `OAuth ${pageToken}`,
                         offset: 0,
-                        file_size: size
+                        file_size: size,
                     },
                 });
                 const isUploadSuccessful = uploadBinaryResponse.data.success;
@@ -205,7 +209,7 @@ app.post("/uploadReels", function (req, res) {
 
 /**
  * Publish Reels on the Selected Page
- * Note that a successful publish request is an acknowledgement that the publish request has been received successfully 
+ * Note that a successful publish request is an acknowledgement that the publish request has been received successfully
  * and doesn't necessarily mean the video was published successfully.
  * In order to confirm that the video was published successfully, a status check request needs to be sent (see /checkStatus).
  **/


### PR DESCRIPTION
This PR changes the way the video upload HTTP request is handled to allow files of more than 10 MB in size, which is the default set by the axios library.
## Before
When uploading a file larger than 10 MB the following error message was shown:
![image](https://user-images.githubusercontent.com/18663703/181614375-88e8d4a7-b2ee-4add-b67f-aa98722c2c34.png)
## After
When uploading a file larger than 10 MB the file is uploaded successfully:
![image](https://user-images.githubusercontent.com/18663703/181614460-c9c69a60-d51f-44fc-8bb3-b9ecf4c0f79f.png)
