### PR TITLE
Fixes typo for publishing phase errors

### DIFF
--- a/fb_reels_publishing_api_sample/index.js
+++ b/fb_reels_publishing_api_sample/index.js
@@ -272,7 +272,7 @@ app.post("/checkStatus", async function (req, res) {
             message = `[Processing Error] Video ID# ${videoId}: ${errorMsgs}`;
             processing = false;
         } else if(statusResponse.data.status.publishing_phase.errors) { // handling errors during publishing video
-            errorMsgs = collectErrorMessagesFromArrayOfErrors(statusResponse.data.status.processing_phase.errors);
+            errorMsgs = collectErrorMessagesFromArrayOfErrors(statusResponse.data.status.publishing_phase.errors);
             message = `[Publishing Error] Video ID# ${videoId}: ${errorMsgs}`;
             processing = true;
         }


### PR DESCRIPTION
Replaces `processing_phase` with `publishing_phase`. This fix will allow publishing errors to be displayed in the sample app.