### PR TITLE
UI to display video reels of a selected page

### DIFF
--- a/fb_reels_publishing_api_sample/index.js
+++ b/fb_reels_publishing_api_sample/index.js
@@ -255,7 +255,7 @@ app.post("/listUploadedVideos", async function(req, res) {
                 } else if (selectedPageID && !videoFile && !videoUrl) {
                     // Retrieve Page Access token corresponding to the selected page
                     const pageToken = req.session.pageData.filter((pd) => pd.id === selectedPageID)[0].access_token;
-                    const videoUri = `https://graph.facebook.com/v13.0/${selectedPageID}/video_reels/?&access_token=${pageToken}`;
+                    const videoUri = `https://graph.facebook.com/v13.0/${selectedPageID}/video_reels/?limit=5&access_token=${pageToken}`;
 
                     const video_response = await axios.get(videoUri);
                     const videos_list = video_response.data.data;
@@ -268,6 +268,12 @@ app.post("/listUploadedVideos", async function(req, res) {
                             message: `No video IDs found associated with the page ${selectedPageID}`,
                         });
                     } else {
+                        // Convert UTC time to user's local time and amend the list
+                        videos_list.forEach((value, index, self) => {
+                            if (value['updated_time']) {
+                                self[index]['updated_time'] = (new Date(value['updated_time'])).toLocaleString();
+                            }
+                        })
                         // Render the Upload page, but now send back the list of past reels of the selected page
                         res.render("upload_page", {
                             uploaded: false,

--- a/fb_reels_publishing_api_sample/index.js
+++ b/fb_reels_publishing_api_sample/index.js
@@ -260,13 +260,22 @@ app.post("/listUploadedVideos", async function(req, res) {
                     const video_response = await axios.get(videoUri);
                     const videos_list = video_response.data.data;
 
-                    // Render the Upload page, but now send back the list of past reels of the selected page
-                    res.render("upload_page", {
-                        uploaded: false,
-                        error: false,
-                        pages: req.session.pageData,
-                        videos: videos_list,
-                    });
+                    if (videos_list.length == 0) {
+                        res.render("upload_page", {
+                            uploaded: false,
+                            error: true,
+                            pages: req.session.pageData,
+                            message: `No video IDs found associated with the page ${selectedPageID}`,
+                        });
+                    } else {
+                        // Render the Upload page, but now send back the list of past reels of the selected page
+                        res.render("upload_page", {
+                            uploaded: false,
+                            error: false,
+                            pages: req.session.pageData,
+                            videos: videos_list,
+                        });
+                    }
                 }
             } catch(error) {
                 res.render("upload_page", {

--- a/fb_reels_publishing_api_sample/index.js
+++ b/fb_reels_publishing_api_sample/index.js
@@ -226,6 +226,53 @@ app.post("/uploadReels", function (req, res) {
 });
 
 /**
+ * List Uploaded Reels of the Selected Page
+ * If No page is selected, stay on the Upload Page and display the error
+ * Else, display all relevant reels of that were previously uploaded for the selected page
+ */
+app.post("/listUploadedVideos", async function(req, res) {
+    // Access all eligible pages for the account
+    const uri = `https://graph.facebook.com/v13.0/me/accounts?access_token=${req.session.userToken}`;
+
+    if (req.session.userToken) {
+        try {
+            const selectedPageID = req.body.videoReelsPageId;
+
+            const response = await axios.get(uri);
+            req.session.pageData = response.data.data;
+
+            if(!selectedPageID) {
+                // page not selected
+                res.render("upload_page", {
+                    uploaded: false,
+                    error: true,
+                    pages: req.session.pageData,
+                    message: "No page has been selected",
+                });
+            }
+            else {
+                // Retrieve Page Access token corresponding to the selected page
+                const pageToken = req.session.pageData.filter((pd) => pd.id === selectedPageID)[0].access_token;
+                const videoUri = `https://graph.facebook.com/v13.0/${selectedPageID}/video_reels/?&access_token=${pageToken}`;
+
+                const video_response = await axios.get(videoUri);
+                const videos_list = video_response.data.data;
+
+                // Render the Upload page, but now send back the list of past reels of the selected page
+                res.render("upload_page", {
+                    uploaded: false,
+                    error: false,
+                    pages: req.session.pageData,
+                    videos: videos_list,
+                });
+            }
+        } catch (error) {
+            res.render("index", { error: "You need to login first"})
+        }
+    }
+});
+
+/**
  * Publish Reels on the Selected Page
  * Note that a successful publish request is an acknowledgement that the publish request has been received successfully
  * and doesn't necessarily mean the video was published successfully.

--- a/fb_reels_publishing_api_sample/index.js
+++ b/fb_reels_publishing_api_sample/index.js
@@ -230,7 +230,7 @@ app.post("/uploadReels", function (req, res) {
  * If No page is selected, stay on the Upload Page and display the error
  * Else, display all relevant reels of that were previously uploaded for the selected page
  */
-app.post("/listUploadedVideos", async function(req, res) {
+app.get("/listUploadedVideos", async function(req, res) {
     // Access all eligible pages for the account
     const uri = `https://graph.facebook.com/v13.0/me/accounts?access_token=${req.session.userToken}`;
 
@@ -239,9 +239,9 @@ app.post("/listUploadedVideos", async function(req, res) {
             const response = await axios.get(uri);
             req.session.pageData = response.data.data;
 
-            const selectedPageID = req.body.pageID;
-            const videoUrl = req.body.videoUrl;
-            const videoFile = req.file;
+            const selectedPageID = req.query.pageID;
+            const videoUrl = req.query.videoUrl;
+            const videoFile = req.query.videoFile;
 
             try {
                 if(!selectedPageID) {

--- a/fb_reels_publishing_api_sample/style.css
+++ b/fb_reels_publishing_api_sample/style.css
@@ -115,3 +115,25 @@ label {
 .optional-parameter-input{
 	margin:3px;
 }
+
+table {
+	margin-left: auto;
+	margin-right: auto;
+	border: 1px solid black;
+	table-layout: auto;
+	width: 100%;
+}
+
+th, td {
+	padding: 10px;
+	text-align: left;
+	border: 1px solid black;
+}
+
+th {
+	padding-top: 12px;
+	padding-bottom: 12px;
+	text-align: left;
+	background-color: #2196F3;
+	color: white;
+}

--- a/fb_reels_publishing_api_sample/upload_page.pug
+++ b/fb_reels_publishing_api_sample/upload_page.pug
@@ -27,7 +27,7 @@ html
           br
           input(type="text" placeholder="Enter video url" name="videoUrl")
           input(type='submit', name='uploadReels', value='Upload Video', onclick="this.form.submit(); this.disabled = true;")
-          input(type='submit', formaction='/listUploadedVideos', name='listUploadedVideos', value='Show Video Reels', onclick="this.form.enctype='application/x-www-form-urlencoded'")
+          input(type='submit', name='listUploadedVideos', value='Show Video Reels', formaction='/listUploadedVideos', formmethod='GET', formenctype='application/x-www-form-urlencoded')
 
       if(videos)
         fieldset

--- a/fb_reels_publishing_api_sample/upload_page.pug
+++ b/fb_reels_publishing_api_sample/upload_page.pug
@@ -27,30 +27,22 @@ html
           br
           input(type="text" placeholder="Enter video url" name="videoUrl")
           input(type='submit', name='uploadReels', value='Upload Video', onclick="this.form.submit(); this.disabled = true;")
+          input(type='submit', formaction='/listUploadedVideos', name='listUploadedVideos', value='Show Video Reels', onclick="this.form.enctype='application/x-www-form-urlencoded'")
 
-      fieldset
-        form(action='/listUploadedVideos', method='POST', enctype="application/x-www-form-urlencoded")
-          b Select a Page to Show all past reels
-          div(class='radio-group')
-            each page, index in pagesArr
-              div(class='radio-child')
-                input(type="radio" id=`page-${index}-reels` name="videoReelsPageId" value=page.id)
-                label(for=`page-${index}-reels`) Page: #{page.name} - #{page.id}
-          input(type='submit', name='listUploadedVideos', value='Show Video Reels', onclick="this.form.submit(); this.disabled = true;")
-
-        if(videos)
-            - let videosArr = videos ?? [];
-            if (videosArr.length > 0)
-              table(class="table table-dark")
+      if(videos)
+        fieldset
+          - let videosArr = videos ?? [];
+          if (videosArr.length > 0)
+            table(class="table")
+              tr
+                th Video ID
+                th Video Description
+                th Updated Time
+              each video, index in videosArr
                 tr
-                  th Video ID
-                  th Video Description
-                  th Updated Time
-                each video, index in videosArr
-                  tr
-                    td #{video.id}
-                    td #{video.description}
-                    td #{video.updated_time}
+                  td #{video.id}
+                  td #{video.description}
+                  td #{video.updated_time}
 
       if(uploaded)
         script(src="/utils.js")

--- a/fb_reels_publishing_api_sample/upload_page.pug
+++ b/fb_reels_publishing_api_sample/upload_page.pug
@@ -31,13 +31,14 @@ html
 
       if(videos)
         fieldset
+          h3 Five Last Created Videos of Page
           - let videosArr = videos ?? [];
           if (videosArr.length > 0)
             table(class="table")
               tr
                 th Video ID
                 th Video Description
-                th Updated Time
+                th Last Updated Time
               each video, index in videosArr
                 tr
                   td #{video.id}

--- a/fb_reels_publishing_api_sample/upload_page.pug
+++ b/fb_reels_publishing_api_sample/upload_page.pug
@@ -28,6 +28,30 @@ html
           input(type="text" placeholder="Enter video url" name="videoUrl")
           input(type='submit', name='uploadReels', value='Upload Video', onclick="this.form.submit(); this.disabled = true;")
 
+      fieldset
+        form(action='/listUploadedVideos', method='POST', enctype="application/x-www-form-urlencoded")
+          b Select a Page to Show all past reels
+          div(class='radio-group')
+            each page, index in pagesArr
+              div(class='radio-child')
+                input(type="radio" id=`page-${index}-reels` name="videoReelsPageId" value=page.id)
+                label(for=`page-${index}-reels`) Page: #{page.name} - #{page.id}
+          input(type='submit', name='listUploadedVideos', value='Show Video Reels', onclick="this.form.submit(); this.disabled = true;")
+
+        if(videos)
+            - let videosArr = videos ?? [];
+            if (videosArr.length > 0)
+              table(class="table table-dark")
+                tr
+                  th Video ID
+                  th Video Description
+                  th Updated Time
+                each video, index in videosArr
+                  tr
+                    td #{video.id}
+                    td #{video.description}
+                    td #{video.updated_time}
+
       if(uploaded)
         script(src="/utils.js")
         .alert


### PR DESCRIPTION
- Separate UI Section created that lists pages that an app has access to. 
- API Endpoint added to list past videos uploaded to a selected page from the newly created UI section. 
- The section errors if a page is not selected. 
- A table with the video ID, description and updated timestamp of the video will be displayed in this section.
- Screenshot attached:

![309614739_469923505121223_2930107481670535065_n](https://user-images.githubusercontent.com/11317519/196523558-3ef91bc6-bf65-4e2d-bc62-2d77107585a1.png)