### PR TITLE
Add support for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM node
+
+RUN wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64
+RUN mv mkcert-v1.4.4-linux-amd64 /usr/bin/mkcert
+RUN chmod +x /usr/bin/mkcert

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"forwardPorts": ["localhost:8000"]
+}

--- a/fb_reels_publishing_api_sample/README.md
+++ b/fb_reels_publishing_api_sample/README.md
@@ -44,6 +44,8 @@ Included in this repo is a sample video (located /sample_media) to be used durin
 
 ### Using a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers)
 
+Note: Ensure that containers are enabled and supported by the version of Visual Studio Code that you are using.
+
 * Navigate to the corresponding subfolder: `cd fb_reels_publishing_api_sample`
 * Run `npm install` in your terminal
 * Create a new file called `.env` and copy/paste all the environment variables from `.env.template`. Replace any environnment variables that have placeholders, such as APP_ID.

--- a/fb_reels_publishing_api_sample/README.md
+++ b/fb_reels_publishing_api_sample/README.md
@@ -10,12 +10,6 @@ You will need the following:
 
 * You will need [Facebook App Secret](https://developers.facebook.com/docs/development/create-an-app/app-dashboard/basic-settings#app-secret) for the Facebook App
 
-* [nodeJS](https://nodejs.org/en/download/) or you can install via Homebrew(MacOS only) - `brew install node`
-
-* [mkcert](https://mkcert.org/) needs to be installed on your server to create the OpenSSL Certificate. If you're using Mac you can install it via Homebrew - `brew install mkcert`
-
-* [Pug](https://pugjs.org/api/getting-started.html) installed on your server to create the UI for the app
-
 For simplicity, this sample guide assumes that you save every file at the root level of the app directory without any nested folder structures except for node modules.
 
 ## Video Requirements for Publishing
@@ -48,6 +42,23 @@ Included in this repo is a sample video (located /sample_media) to be used durin
 
 ## Running the project
 
+### Using a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers)
+
+* Navigate to the corresponding subfolder: `cd fb_reels_publishing_api_sample`
+* Run `npm install` in your terminal
+* Create a new file called `.env` and copy/paste all the environment variables from `.env.template`. Replace any environnment variables that have placeholders, such as APP_ID.
+* Create an OpenSSL Cert
+    * `mkcert localhost` - This will create a localhost pem file
+    * You will see `localhost.pem` and `localhost-key.pem `files generated.
+
+* Running the Sample App
+    * `npm start`
+    * Once the sample app starts running, go to https://localhost:8000 to test the workflow.
+
+### Locally
+
+* Install [nodeJS](https://nodejs.org/en/download/), which you can get via Homebrew (MacOS only) - `brew install node`
+* Install [mkcert](https://mkcert.org/) to create the OpenSSL Certificate. If you're using Mac you can install it via Homebrew - `brew install mkcert`
 * Run `npm install` in your terminal
 * Create a new file called `.env` and copy/paste all the environment variables from `.env.template`. Replace any environnment variables that have placeholders, such as APP_ID.
 

--- a/insta_reels_publishing_api_sample/CHANGELOG.md
+++ b/insta_reels_publishing_api_sample/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2023-03-02
+
+### Added
+- Support for devcontainers
+
 ## [2.0.0] - 2023-02-14
 
 ### Added 

--- a/insta_reels_publishing_api_sample/README.md
+++ b/insta_reels_publishing_api_sample/README.md
@@ -18,12 +18,6 @@ You will need the following:
 
 * You will need [Facebook App Secret](https://developers.facebook.com/docs/development/create-an-app/app-dashboard/basic-settings#app-secret) for the Facebook App
 
-* [nodeJS](https://nodejs.org/en/download/) or you can install via Homebrew(MacOS only) - `brew install node`
-
-* [mkcert](https://mkcert.org/) needs to be installed on your server to create the OpenSSL Certificate. If you're using Mac you can install it via Homebrew - `brew install mkcert`
-
-* [Pug](https://pugjs.org/api/getting-started.html) installed on your server to create the UI for the app
-
 * If testing the [Location Tagging](https://developers.facebook.com/docs/instagram-api/guides/content-publishing/#location-tags) feature in the sample app, ensure to go through the pre-requisites for your Facebook App for the required permissions.
     * The Location tagging feature requires your app to have access to the [Pages Search API](https://developers.facebook.com/docs/pages/searching) to search for [Pages](https://developers.facebook.com/docs/graph-api/reference/page) whose names match a search string.
     * The [Pages Search API](https://developers.facebook.com/docs/pages/searching) requires the following pre-requisites to be met:
@@ -91,6 +85,23 @@ Please note: This feature **IS NOT** included in the Sample App.
 
 ## Running the project
 
+### Using a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers)
+
+* Navigate to the corresponding subfolder: `cd insta_reels_publishing_api_sample`
+* Run `npm install` in your terminal
+* Create a new file called `.env` and copy/paste all the environment variables from `.env.template`. Replace any environnment variables that have placeholders, such as APP_ID.
+* Create an OpenSSL Cert
+    * `mkcert localhost` - This will create a localhost pem file
+    * You will see `localhost.pem` and `localhost-key.pem `files generated.
+
+* Running the Sample App
+    * `npm start`
+    * Once the sample app starts running, go to https://localhost:8000 to test the workflow.
+
+### Locally
+
+* Install [nodeJS](https://nodejs.org/en/download/), which you can get via Homebrew (MacOS only) - `brew install node`
+* Install [mkcert](https://mkcert.org/) to create the OpenSSL Certificate. If you're using Mac you can install it via Homebrew - `brew install mkcert`
 * Run `npm install` in your terminal
 * Create a new file called `.env` and copy/paste all the environment variables from `.env.template`. Replace any environnment variables that have placeholders, such as APP_ID.
 

--- a/insta_reels_publishing_api_sample/README.md
+++ b/insta_reels_publishing_api_sample/README.md
@@ -87,6 +87,8 @@ Please note: This feature **IS NOT** included in the Sample App.
 
 ### Using a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers)
 
+Note: Ensure that containers are enabled and supported by the version of Visual Studio Code that you are using.
+
 * Navigate to the corresponding subfolder: `cd insta_reels_publishing_api_sample`
 * Run `npm install` in your terminal
 * Create a new file called `.env` and copy/paste all the environment variables from `.env.template`. Replace any environnment variables that have placeholders, such as APP_ID.


### PR DESCRIPTION
This PR adds support to run the sample apps using a devcontainer, which is supported by [VS Code](https://code.visualstudio.com/docs/devcontainers/containers) and [GitHub Codespaces](https://github.com/features/codespaces).

<img width="569" alt="image" src="https://user-images.githubusercontent.com/18663703/218905599-4e8c9fd2-692d-419f-a371-ec1525b85d78.png">

<img width="529" alt="image" src="https://user-images.githubusercontent.com/18663703/218905863-09d98e03-c0e3-4c9e-b8e1-eb5fe11c985d.png">

This feature removes the need to install node and mkcert locally, as they are moved to a Decker container. The readme files are updated with two options to run the apps: using a devcontainer or locally.

I also removed from the documentation the requirement to install pug, as it was handled by the `npm install` command.