### PR TITLE
Display Instagram accounts instead of FB pages

### DIFF
--- a/insta_reels_publishing_api_sample/CHANGELOG.md
+++ b/insta_reels_publishing_api_sample/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Support for devcontainers
 
+### Changed
+- Showing the list of Instagram accounts instead of Facebook pages
+
 ## [2.0.0] - 2023-02-14
 
 ### Added 

--- a/insta_reels_publishing_api_sample/index.js
+++ b/insta_reels_publishing_api_sample/index.js
@@ -121,7 +121,12 @@ app.get("/pages", async function (req, res) {
         .filter(batchResponse => batchResponse.code === 200)
         .map(batchResponse => JSON.parse(batchResponse.body))
         .filter(singleApiResponse => singleApiResponse.instagram_business_account !== undefined)
-        .map(singleApiResponse => singleApiResponse.instagram_business_account);
+        .map(singleApiResponse => singleApiResponse.instagram_business_account)
+        .map(businessAccount => ({
+            displayName: `@${businessAccount.username}` +
+                (businessAccount.name ? ` (${businessAccount.name})` : ''),
+            ...businessAccount,
+        }));
 
     res.render('upload_page', {
         'accounts': instagramData,

--- a/insta_reels_publishing_api_sample/index.js
+++ b/insta_reels_publishing_api_sample/index.js
@@ -97,7 +97,7 @@ app.get("/pages", async function (req, res) {
     // Retrieve the Instagram Businesses associated with each page, if any, in a single HTTP request
     const batchParamValue = pagesData.map(pageData => ({
         method: "GET",
-        relative_url: `${pageData.id}/?fields=instagram_business_account{name,username}`,
+        relative_url: `${pageData.id}?fields=instagram_business_account{name,username}`,
         access_token: pageData.access_token,
     }));
     let batchResponses;

--- a/insta_reels_publishing_api_sample/index.js
+++ b/insta_reels_publishing_api_sample/index.js
@@ -77,21 +77,55 @@ app.get("/callback", async function (req, res) {
 // Pages route to retrieve FB OAuth page tokens
 app.get("/pages", async function (req, res) {
     const associatedPagesUri = `https://graph.facebook.com/v14.0/me/accounts?access_token=${req.session.userToken}`;
-    if (req.session.userToken) {
-        try {
-            const associatedPages = await axios.get(associatedPagesUri);
-            req.session.pageData = associatedPages.data.data;
-            res.render('upload_page', {
-                'pages': req.session.pageData
-            });
-        } catch (error) {
-            res.render("index", {
-                error: `There was an error with the request: ${error}`,
-            });
-        }
-    } else {
+    if (!req.session.userToken) {
         res.render("index", { error: "You need to log in first" });
+        return;
     }
+
+    // Request all associated Facebook pages
+    let pagesData = [];
+    try {
+        const accountsResponse = await axios.get(associatedPagesUri);
+        pagesData = accountsResponse.data.data;
+    } catch (error) {
+        res.render("index", {
+            error: `There was an error requesting the FB pages: ${error}`,
+        });
+        return;
+    }
+
+    // Retrieve the Instagram Businesses associated with each page, if any, in a single HTTP request
+    const batchParamValue = pagesData.map(pageData => ({
+        method: "GET",
+        relative_url: `${pageData.id}/?fields=instagram_business_account{name,username}`,
+        access_token: pageData.access_token,
+    }));
+    let batchResponses;
+    try {
+        batchResponses = await axios({
+            method: 'POST',
+            url: `https://graph.facebook.com/?access_token=${req.session.userToken}&include_headers=false`,
+            data: {
+                batch: batchParamValue,
+            },
+        });
+    } catch (error) {
+        res.render("index", {
+            error: `There was an error requesting the Instagram businesses: ${error}`,
+        });
+        return;
+    }
+
+    // Take only the Instagram business account info for those pages that had them connected
+    const instagramData = batchResponses.data
+        .filter(batchResponse => batchResponse.code === 200)
+        .map(batchResponse => JSON.parse(batchResponse.body))
+        .filter(singleApiResponse => singleApiResponse.instagram_business_account !== undefined)
+        .map(singleApiResponse => singleApiResponse.instagram_business_account);
+
+    res.render('upload_page', {
+        'accounts': instagramData,
+    });
 });
 
 // Endpoint to retrieve locations matching a search term
@@ -109,7 +143,6 @@ app.get("/listLocations", async function (req, res) {
             req.session.locationData = locationsList.data.data;
 
             res.render('upload_page', {
-                pages: req.session.pageData,
                 locations_list: req.session.locationData
             });
         } catch (error) {
@@ -123,67 +156,40 @@ app.get("/listLocations", async function (req, res) {
 });
 
 app.post("/uploadReels", async function (req, res) {
-    const selectedPageID = req.body.pageID;
+    const { videoUrl, caption, coverUrl, thumbOffset, accountId } = req.body;
+    let { locationId } = req.body;
+    if(typeof locationId === 'undefined') {
+        locationId = "";
+    }
+    const uploadParamsString = `caption=${caption}&cover_url=${coverUrl}&thumb_offset=${thumbOffset}&location_id=${locationId}&access_token=${req.session.userToken}`;
+    const uploadVideoUri = `https://graph.facebook.com/v14.0/${accountId}/media?media_type=REELS&video_url=${videoUrl}&${uploadParamsString}`;
+
     try {
-         // Now Retrieve the Instgram user ID associated with the selected page
-        const getInstagramAccountUri = `https://graph.facebook.com/v14.0/${selectedPageID}?fields=instagram_business_account&access_token=${req.session.userToken}`;
-        const igResponse = await axios.get(getInstagramAccountUri);
-        const hasIgBusinessAccount = igResponse.data.instagram_business_account ? true : false;
-        const igUserId = igResponse.data.instagram_business_account.id;
-        const { videoUrl, caption, coverUrl, thumbOffset } = req.body;
-        let { locationId } = req.body;
-        if(typeof locationId === 'undefined') {
-            locationId = "";
-        }
-        const uploadParamsString = `caption=${caption}&cover_url=${coverUrl}&thumb_offset=${thumbOffset}&location_id=${locationId}&access_token=${req.session.userToken}`;
-        const uploadVideoUri = `https://graph.facebook.com/v14.0/${igUserId}/media?media_type=REELS&video_url=${videoUrl}&${uploadParamsString}`;
+        // Upload Reel Video
+        const uploadResponse = await axios.post(uploadVideoUri);
+        const containerId = uploadResponse.data.id;
 
-        // If there is a IG Business Account associated with the page
-        if(hasIgBusinessAccount) {
-            try {
-                // Upload Reel Video
-                const uploadResponse = await axios.post(uploadVideoUri);
-                const containerId = uploadResponse.data.id;
+        // add variables to the session
+        Object.assign(req.session, { accountId, containerId });
 
-                // add variables to the session
-                Object.assign(req.session, { igUserId, containerId });
-
-                // Render Upload Success
-                res.render("upload_page", {
-                    uploaded: true,
-                    igUserId,
-                    containerId,
-                    pages: req.session.pageData,
-                    message: `Reel uploaded successfully on IG UserID #${igUserId} at Container ID #${containerId}. You can Publish now.`
-                });
-            } catch(e) {
-                res.render("upload_page", {
-                    uploaded: false,
-                    error: true,
-                    pages: req.session.pageData,
-                    message: `Error during upload. [Selected page id - ${selectedPageID}, IG User ID - ${igUserId}`
-                });
-            }
-        } else { // Error - No IG Account found
-            res.render("upload_page", {
-                uploaded: false,
-                error: true,
-                pages: req.session.pageData,
-                message: "No Instagram Business Account associated with the page!"
-            });
-        }
+        // Render Upload Success
+        res.render("upload_page", {
+            uploaded: true,
+            accountId,
+            containerId,
+            message: `Reel uploaded successfully on IG UserID #${accountId} at Container ID #${containerId}. You can Publish now.`
+        });
     } catch(e) {
         res.render("upload_page", {
             uploaded: false,
             error: true,
-            pages: req.session.pageData,
-            message: `Error in getting IG account details for the selected page id - ${selectedPageID}`
+            message: `Error during upload. [Selected account id - ${accountId}`
         });
     }
 });
 
 app.post("/publishReels", async function (req, res) {
-    const { igUserId, containerId } = req.session;
+    const { accountId, containerId } = req.session;
 
     // Upload happens asynchronously in the backend,
     // so you need to check upload status before you Publish
@@ -192,11 +198,11 @@ app.post("/publishReels", async function (req, res) {
 
     // When uploaded successfully, publish the video
     if(isUploaded) {
-        const publishVideoUri = `https://graph.facebook.com/v14.0/${igUserId}/media_publish?creation_id=${containerId}&access_token=${req.session.userToken}`;
+        const publishVideoUri = `https://graph.facebook.com/v14.0/${accountId}/media_publish?creation_id=${containerId}&access_token=${req.session.userToken}`;
         const publishResponse = await axios.post(publishVideoUri);
         const publishedMediaId = publishResponse.data.id;
 
-        const rateLimitCheckUrl = `https://graph.facebook.com/v14.0/${igUserId}/content_publishing_limit?fields=config,quota_usage&access_token=${req.session.userToken}`;
+        const rateLimitCheckUrl = `https://graph.facebook.com/v14.0/${accountId}/content_publishing_limit?fields=config,quota_usage&access_token=${req.session.userToken}`;
         const rateLimitResponse = await axios.get(rateLimitCheckUrl);
         const { config: {quota_total}, quota_usage} = rateLimitResponse.data.data[0];
         const usageRemaining = quota_total - quota_usage;
@@ -210,12 +216,11 @@ app.post("/publishReels", async function (req, res) {
         res.render("upload_page", {
             uploaded: true,
             published: true,
-            igUserId,
+            accountId,
             permalink,
             publishedMediaId,
-            pages: req.session.pageData,
             message: [
-                `Reel Published successfully on IG UserID #${igUserId} with Publish Media ID #${publishedMediaId}`,
+                `Reel Published successfully on IG UserID #${accountId} with Publish Media ID #${publishedMediaId}`,
                 `Publishes remaining - ${usageRemaining}`
             ]
         });
@@ -223,7 +228,6 @@ app.post("/publishReels", async function (req, res) {
         res.render("upload_page", {
             uploaded: false,
             error: true,
-            pages: req.session.pageData,
             message: "Reel Upload Failed for IG UserID #${igUserId} !"
         });
     }

--- a/insta_reels_publishing_api_sample/upload_page.pug
+++ b/insta_reels_publishing_api_sample/upload_page.pug
@@ -21,7 +21,7 @@ html
                             div(class='radio-child')
                                 label(for=`account-${index}`)
                                     input(type='radio' id=`account-${index}` name="accountId" value=account.id)
-                                    |  Account: @#{account.username} (#{account.name}) - #{account.id}
+                                    |  Account: #{account.displayName} - #{account.id}
                     input(type="text" placeholder="Enter video url" name="videoUrl")
                     input(type="text" placeholder="Enter caption (optional)" name="caption")
                     br

--- a/insta_reels_publishing_api_sample/upload_page.pug
+++ b/insta_reels_publishing_api_sample/upload_page.pug
@@ -12,16 +12,16 @@ html
         header
             h1 Instagram Reels Publishing API Sample App
         .canvas
-            - let pagesArr = pages ?? [];
-            if (pagesArr.length > 0)
+            - let accountsArr = accounts ?? [];
+            if (accountsArr.length > 0)
                 form(action='/uploadReels' name="uploadForm" id="uploadForm" method='POST')
-                    b Select an Page associated with Instagram Business Account ID to publish reel to
+                    b Select an Instagram Business Account to publish reel to
                     div(class='radio-group')
-                        each page, index in pagesArr
+                        each account, index in accountsArr
                             div(class='radio-child')
-                                label(for=`page-${index}`)
-                                    input(type='radio' id=`page-${index}` name="pageID" value=page.id)
-                                    |  Page: #{page.name} - #{page.id}
+                                label(for=`account-${index}`)
+                                    input(type='radio' id=`account-${index}` name="accountId" value=account.id)
+                                    |  Account: @#{account.username} (#{account.name}) - #{account.id}
                     input(type="text" placeholder="Enter video url" name="videoUrl")
                     input(type="text" placeholder="Enter caption (optional)" name="caption")
                     br
@@ -63,7 +63,7 @@ html
                                                         td #{location.link}
                     input(type='submit' value='Upload' onclick="this.form.submit(); this.disabled = true;")
             if(uploaded)
-                if(igUserId && containerId)
+                if(accountId && containerId)
                     .alert
                         span.closebtn(onclick="this.parentElement.style.display='none';") &times;
                         |   #{message}
@@ -82,7 +82,7 @@ html
                 if(permalink)
                     a(href=permalink target="_blank") Link to Instagram Post
             else if(!uploaded)
-                if(igUserId)
+                if(accountId)
                     .alert
                         span.closebtn(onclick="this.parentElement.style.display='none';") &times;
                         |   #{message}


### PR DESCRIPTION
This PR updates the Instagram (IG) sample app to display only the list of eligible accounts that can be used with the Content Publishing API. This removes the need of having to guess which of the Facebook (FB) pages has a connected IG Business Account and makes it clear to the user to which account they are posting the content to.

The eligible IG accounts are determined using a [batch API request](https://developers.facebook.com/docs/graph-api/batch-requests) for each of the pages available to the user.

## Before

- A (potentially long) list of FB pages is shown in the UI.

![image](https://user-images.githubusercontent.com/18663703/222178113-76cef50a-1641-4664-96db-d75ad967de3c.png)

- A generic error is shown if the FB page selected by the user does not have a connected IG account

![image](https://user-images.githubusercontent.com/18663703/222178273-d07e255a-176d-458e-a54c-48c2a8c19db2.png)

## After

- A list of IG accounts is shown

![image](https://user-images.githubusercontent.com/18663703/222177575-85bfaeb4-2a75-4a3e-86cc-d462dc30f841.png)

- It is possible to publish using the selected account

![image](https://user-images.githubusercontent.com/18663703/222177834-0c786b93-178c-4f12-b4c5-69ea553c2642.png)
