### PR TITLE
Validate access to IG Content Publishing API

### DIFF
--- a/insta_reels_publishing_api_sample/CHANGELOG.md
+++ b/insta_reels_publishing_api_sample/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Showing the list of Instagram accounts instead of Facebook pages
+- Validate access to the API using Publishing Limit endpoint
 
 ## [2.0.0] - 2023-02-14
 

--- a/insta_reels_publishing_api_sample/upload_page.pug
+++ b/insta_reels_publishing_api_sample/upload_page.pug
@@ -15,7 +15,7 @@ html
             - let accountsArr = accounts ?? [];
             if (accountsArr.length > 0)
                 form(action='/uploadReels' name="uploadForm" id="uploadForm" method='POST')
-                    b Select an Instagram Business Account to publish reel to
+                    b Select an Instagram Professional Account to publish reel to
                     div(class='radio-group')
                         each account, index in accountsArr
                             div(class='radio-child')

--- a/insta_reels_publishing_api_sample/upload_page.pug
+++ b/insta_reels_publishing_api_sample/upload_page.pug
@@ -20,7 +20,7 @@ html
                         each account, index in accountsArr
                             div(class='radio-child')
                                 label(for=`account-${index}`)
-                                    input(type='radio' id=`account-${index}` name="accountId" value=account.id)
+                                    input(type='radio' id=`account-${index}` name="accountId" value=account.id disabled=account.disabled)
                                     |  Account: #{account.displayName} - #{account.id}
                     input(type="text" placeholder="Enter video url" name="videoUrl")
                     input(type="text" placeholder="Enter caption (optional)" name="caption")


### PR DESCRIPTION
This PR adds the ability to verify which Instagram accounts have access to the API and disables those that are unable to publish using this mechanism.

The verification is done using a [batch request](https://developers.facebook.com/docs/graph-api/batch-requests) to the [Content Publishing Limit endpoint](https://developers.facebook.com/docs/instagram-api/reference/ig-user/content_publishing_limit) and disabling those accounts for which their respective call fails.

I also modified the header to clarify that the API call that returns business accounts returns all [professional accounts](https://www.facebook.com/help/instagram/138925576505882) ([business](https://help.instagram.com/502981923235522) and [creator](https://help.instagram.com/2358103564437429) accounts). As of today, business accounts will be enabled and creator accounts will be disabled.

## Before
All professional accounts are displayed as options.

<img width="694" alt="image" src="https://user-images.githubusercontent.com/18663703/222537999-a92d4a5c-33ec-4510-b829-94ea97b7cfe1.png">

An error is shown if the user tries to publish from an account that does not have access to the API.

![image](https://user-images.githubusercontent.com/18663703/222537098-90bb9b6b-c420-4983-9ed9-baa5e51abedb.png)

## After
Accounts that don't have access to the API are disabled.

<img width="702" alt="image" src="https://user-images.githubusercontent.com/18663703/222537670-c4acca4a-214f-4efc-a269-2cfd1ee7631a.png">
