### PR TITLE
Add business management permission

### DIFF
--- a/insta_reels_publishing_api_sample/index.js
+++ b/insta_reels_publishing_api_sample/index.js
@@ -27,6 +27,7 @@ const {
 
 // Access scopes required for the token
 const SCOPES = [
+    "business_management",
     "pages_read_engagement",
     "pages_show_list",
     "instagram_basic",


### PR DESCRIPTION
This PR adds the `business_management` permission to the list of scopes requested as part of the FB Login flow of the Instagram sample app.

Starting with Graph API v17, this permission is required to retrieve the linked Instagram professional accounts using the `/me/accounts` endpoint.

From the [API changelog](https://developers.facebook.com/docs/graph-api/changelog/version17.0#user-accounts):

> The GET /{user-id}/accounts (aka GET /me/accounts) endpoint no longer returns Facebook pages that have been linked to a Meta business account, unless the app user has granted the business_management permission to the app and has a role on the linked business account.

## Before
<img width="562" alt="Screenshot 2023-09-26 at 1 19 50 PM" src="https://github.com/fbsamples/reels_publishing_apis/assets/18663703/a014965f-9c19-44e3-9af5-257d46e7febe">

## After
<img width="535" alt="Screenshot 2023-09-26 at 1 23 05 PM" src="https://github.com/fbsamples/reels_publishing_apis/assets/18663703/7adec3ac-a6b5-46b2-b358-972ed3e9d3e0">