### PR TITLE
fix: publishing limits error

### DIFF
--- a/insta_reels_publishing_api_sample/index.js
+++ b/insta_reels_publishing_api_sample/index.js
@@ -166,7 +166,7 @@ app.get("/pages", async function (req, res) {
         await getBatchRequestResponse(req.session.userToken, publishingLimitBatchParamValue, publishingLimitInfoFunc);
     if (publishingLimitsResult.error) {
         res.render("index", {
-            error: `There was an error requesting the Publishing Limits: ${error}`,
+            error: `There was an error requesting the Publishing Limits: ${publishingLimitsResult.error}`,
         });
         return;
     }


### PR DESCRIPTION
Switching this piece of code to Typescript, I noticed that `error` does not exists.
I guess we are referring to `publishingLimitsResult.error` here.