### PR TITLE
fix: add missing return before recursive isUploadSuccessful call

### DIFF
--- a/insta_reels_publishing_api_sample/utils.js
+++ b/insta_reels_publishing_api_sample/utils.js
@@ -21,17 +21,13 @@ function _wait(n) { return new Promise(resolve => setTimeout(resolve, n)); }
  * @returns Promise<boolean>
  */
 const isUploadSuccessful = async(retryCount, checkStatusUri) => {
-    try {
-        if (retryCount > 30) return false;
-        const response = await axios.get(checkStatusUri);
-        if(response.data.status_code != "FINISHED") {
-            await _wait(3000);
-            return await isUploadSuccessful(retryCount+1, checkStatusUri);
-        }
-        return true;
-    } catch(e) {
-        throw e;
+    if (retryCount > 30) return false;
+    const response = await axios.get(checkStatusUri);
+    if(response.data.status_code != "FINISHED") {
+        await _wait(3000);
+        return await isUploadSuccessful(retryCount+1, checkStatusUri);
     }
+    return true;
 }
 module.exports = {
     isUploadSuccessful

--- a/insta_reels_publishing_api_sample/utils.js
+++ b/insta_reels_publishing_api_sample/utils.js
@@ -26,7 +26,7 @@ const isUploadSuccessful = async(retryCount, checkStatusUri) => {
         const response = await axios.get(checkStatusUri);
         if(response.data.status_code != "FINISHED") {
             await _wait(3000);
-            await isUploadSuccessful(retryCount+1, checkStatusUri);
+            return await isUploadSuccessful(retryCount+1, checkStatusUri);
         }
         return true;
     } catch(e) {


### PR DESCRIPTION
Without return, the recursive result was discarded and upload failures were never detected.