### PR TITLE
chore: remove unnecessary fs and path from dependencies

### DIFF
--- a/insta_reels_publishing_api_sample/package.json
+++ b/insta_reels_publishing_api_sample/package.json
@@ -15,9 +15,7 @@
     "dotenv": "^16.0.1",
     "express": "^4.17.3",
     "express-session": "^1.17.2",
-    "fs": "^0.0.1-security",
     "multer": "2.1.1",
-    "path": "^0.12.7",
     "pug": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Both are Node.js built-ins; the npm packages are unnecessary stubs.