### PR TITLE
Add Resumable Upload API support to the Instagram sample app

### DIFF
--- a/insta_reels_publishing_api_sample/CHANGELOG.md
+++ b/insta_reels_publishing_api_sample/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2024-06-12
+
+### Added
+- Resumable Upload support for uploading local video files via `upload_type=resumable`
+- File input on the upload form alongside the existing URL input
+- Video file format validation via multer
+
 ## [2.0.1] - 2023-03-02
 
 ### Added

--- a/insta_reels_publishing_api_sample/README.md
+++ b/insta_reels_publishing_api_sample/README.md
@@ -56,6 +56,14 @@ Custom Thumbnail support has been included in the sample app as of version 2.0.0
 ### Cover URL `cover_url`
 Cover URL support has been included in the sample app as of version 2.0.0. This is the path to an image to use as the cover image for the Reels tab. The image specified will be cURLed hence the image must be on a public server. If both `cover_url` and `thumb_offset` are specified, `cover_url` is used and `thumb_offset` will be ignored. The image must conform to the specifications for a [Reels cover photo](https://developers.facebook.com/docs/instagram-api/reference/ig-user/media#reels-specs).
 
+### Resumable Upload (File Upload) `upload_type=resumable`
+Resumable upload support has been included in the sample app as of version 3.0.0. Instead of providing a video URL for Instagram to fetch, you can upload a local video file directly from your computer. The app uses the [Resumable Upload Protocol](https://developers.facebook.com/docs/instagram-api/guides/content-publishing) to:
+1. Create a media container with `upload_type=resumable`, which returns a container ID and an upload URI
+2. Upload the video binary to the returned upload URI at `rupload.facebook.com`
+3. Poll for upload completion and publish as usual
+
+You can use either a video URL **or** a file upload, but not both simultaneously. The maximum file size is 1GB per the Instagram Reels specification. Supported video formats include MP4, MOV, MKV, AVI, and others listed in the [Reels Requirements for Publishing](#reels-requirements-for-publishing) section above.
+
 ### Location Tagging `location_id`
 Location Tagging feature has been included in the sample app as of version 2.0.0. The [`location_id` parameter](https://developers.facebook.com/docs/instagram-api/reference/ig-user/media#query-string-parameters) refers to the ID of a Page associated with a location that you want to tag the reel with. Ensure to refer to pre-requisites required to search for Pages in the [Before you start](#before-you-start) section of this README.
 

--- a/insta_reels_publishing_api_sample/asyncStatusRefresh.js
+++ b/insta_reels_publishing_api_sample/asyncStatusRefresh.js
@@ -1,0 +1,145 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//  All rights reserved.
+//  This source code is licensed under the license found in the
+//  LICENSE file in the root directory of this source tree.
+
+var pollCount = 0;
+var asyncInterval = setInterval(fetchStatus, 3500);
+
+async function fetchStatus() {
+    pollCount++;
+    showLoading();
+
+    try {
+        var response = await fetch('/asyncStatus');
+        var data = await response.json();
+        updateStatus(data);
+        updateRawResponse(data);
+
+        if (data.status_code === 'FINISHED') {
+            clearInterval(asyncInterval);
+            var btn = document.getElementById('publish-button');
+            btn.disabled = false;
+            btn.value = 'Publish';
+        } else if (data.status_code === 'ERROR' || data.status_code === 'EXPIRED' || hasPhaseError(data)) {
+            clearInterval(asyncInterval);
+        }
+    } catch (err) {
+        clearInterval(asyncInterval);
+        hideLoading();
+        var ele = document.getElementById('upload-status');
+        if (ele) {
+            ele.innerHTML = '<span style="color:#a51414;font-weight:bold">Failed to check status: ' + err.message + '</span>';
+        }
+    }
+}
+
+function showLoading() {
+    var indicator = document.getElementById('loading-indicator');
+    if (indicator) {
+        indicator.style.display = 'inline';
+    }
+}
+
+function hideLoading() {
+    var indicator = document.getElementById('loading-indicator');
+    if (indicator) {
+        indicator.style.display = 'none';
+    }
+}
+
+function hasPhaseError(data) {
+    if (!data.video_status) return false;
+    var uploading = data.video_status.uploading_phase;
+    var processing = data.video_status.processing_phase;
+    return (uploading && uploading.status === 'error') ||
+           (processing && processing.status === 'error');
+}
+
+function collectPhaseErrors(data) {
+    var messages = [];
+    if (!data.video_status) return messages;
+    var phases = [
+        { name: 'Upload', phase: data.video_status.uploading_phase },
+        { name: 'Processing', phase: data.video_status.processing_phase },
+    ];
+    for (var i = 0; i < phases.length; i++) {
+        var p = phases[i];
+        if (p.phase && p.phase.errors) {
+            for (var j = 0; j < p.phase.errors.length; j++) {
+                var err = p.phase.errors[j];
+                messages.push(p.name + ' error (code ' + err.code + '): ' + err.message);
+            }
+        }
+    }
+    return messages;
+}
+
+function formatBytes(bytes) {
+    if (bytes === 0) return '0 B';
+    var sizes = ['B', 'KB', 'MB', 'GB'];
+    var i = Math.floor(Math.log(bytes) / Math.log(1024));
+    return (bytes / Math.pow(1024, i)).toFixed(1) + ' ' + sizes[i];
+}
+
+function updateStatus(data) {
+    hideLoading();
+    var ele = document.getElementById('upload-status');
+    if (!ele) return;
+
+    var parts = [];
+
+    // Status code
+    var isError = data.status_code === 'ERROR' || data.status_code === 'EXPIRED' || hasPhaseError(data);
+    if (data.status_code === 'FINISHED') {
+        parts.push('<span style="color:#3b9610;font-weight:bold">FINISHED</span>');
+    } else if (isError) {
+        parts.push('<span style="color:#a51414;font-weight:bold">' + data.status_code + '</span>');
+    } else {
+        parts.push('<span style="font-weight:bold">' + (data.status_code || 'UNKNOWN') + '</span>');
+    }
+
+    // Upload phase
+    if (data.video_status && data.video_status.uploading_phase) {
+        var uploading = data.video_status.uploading_phase;
+        var uploadText = 'Upload: ' + uploading.status;
+        if (uploading.bytes_transferred !== undefined) {
+            uploadText += ' (' + formatBytes(uploading.bytes_transferred) + ' transferred)';
+        }
+        parts.push(uploadText);
+    }
+
+    // Processing phase
+    if (data.video_status && data.video_status.processing_phase) {
+        var processing = data.video_status.processing_phase;
+        parts.push('Processing: ' + processing.status);
+    }
+
+    ele.innerHTML = parts.join(' &bull; ');
+
+    // Show error details
+    var errorBox = document.getElementById('status-error');
+    if (isError) {
+        if (errorBox) {
+            var phaseErrors = collectPhaseErrors(data);
+            var errorMsg = '';
+            if (phaseErrors.length > 0) {
+                errorMsg = phaseErrors.join('<br>');
+            } else if (data.status) {
+                errorMsg = data.status;
+            } else {
+                errorMsg = 'No error details available from the API.';
+            }
+            errorBox.innerHTML = '<strong>Error:</strong> ' + errorMsg;
+            errorBox.style.display = 'block';
+        }
+    } else if (errorBox) {
+        errorBox.style.display = 'none';
+    }
+}
+
+function updateRawResponse(data) {
+    var ele = document.getElementById('raw-response');
+    if (!ele) return;
+    ele.textContent = JSON.stringify(data, null, 2);
+}

--- a/insta_reels_publishing_api_sample/index.js
+++ b/insta_reels_publishing_api_sample/index.js
@@ -14,9 +14,31 @@ const https = require("https");
 const path = require("path");
 const fs = require("fs");
 const { isUploadSuccessful } = require("./utils");
+const multer = require("multer");
 const { URLSearchParams } = require("url");
 
 const DEFAULT_GRAPH_API_ORIGIN = 'https://graph.facebook.com';
+
+const storageDestinationAtRoot = "local/store/videos";
+const uploadSizeLimit = 1000000000; // 1GB per IG Reels spec
+
+const videoUpload = multer({
+    storage: multer.diskStorage({
+        destination: storageDestinationAtRoot,
+        filename: (req, file, cb) => {
+            cb(null, file.fieldname + "_" + Date.now() + path.extname(file.originalname));
+        },
+    }),
+    limits: {
+        fileSize: uploadSizeLimit,
+    },
+    fileFilter(req, file, cb) {
+        if (!file.originalname.match(/\.(3g2|3gp|3gpp|asf|avi|dat|divx|dv|f4v|flv|m2ts|m4v|mkv|mod|mov|mp4|mpe|mpeg|mpeg4|mpg|mts|nsv|ogm|ogv|qt|tod|ts|vob|wmv)$/i)) {
+            return cb(new Error("Please upload a video in a supported format"));
+        }
+        cb(undefined, true);
+    },
+});
 const DEFAULT_GRAPH_API_VERSION = '';
 
 // Read variables from environment
@@ -214,44 +236,143 @@ app.get("/listLocations", async function (req, res) {
     }
 });
 
-app.post("/uploadReels", async function (req, res) {
-    const { videoUrl, caption, coverUrl, thumbOffset, accountId } = req.body;
-    let { locationId, isStories } = req.body;
-    if(typeof locationId === 'undefined') {
-        locationId = "";
-    }
-    const product = isStories !== undefined ? "STORIES" : "REELS";
-    const uploadVideoUri = buildGraphAPIURL(`${accountId}/media`, {
-        media_type: product,
-        video_url: videoUrl,
-        caption,
-        cover_url: coverUrl,
-        thumb_offset: thumbOffset,
-        location_id: locationId,
-    }, req.session.userToken);
-    
-    try {
-        // Upload Reel Video
-        const uploadResponse = await axios.post(uploadVideoUri);
-        const containerId = uploadResponse.data.id;
+app.post("/uploadReels", function (req, res) {
+    const uploadSingleVideo = videoUpload.single("videoFile");
+    uploadSingleVideo(req, res, async function (err) {
+        const { caption, coverUrl, thumbOffset, accountId } = req.body;
+        let { locationId, isStories } = req.body;
+        const videoUrl = req.body.videoUrl;
+        const videoFile = req.file;
 
-        // add variables to the session
-        Object.assign(req.session, { accountId, containerId });
+        if (typeof locationId === 'undefined') {
+            locationId = "";
+        }
 
-        // Render Upload Success
-        res.render("upload_page", {
-            uploaded: true,
-            accountId,
-            containerId,
-            message: `${product.toLowerCase()} uploaded successfully on IG UserID #${accountId} at Container ID #${containerId}. You can Publish now.`
-        });
-    } catch(e) {
-        res.render("upload_page", {
-            uploaded: false,
-            error: true,
-            message: `Error during upload. [Selected account id - ${accountId}]: ${e.response.data.error}`,
-        });
-    }
+        if (videoUrl && videoFile) {
+            res.render("upload_page", {
+                uploaded: false,
+                error: true,
+                accounts: req.session.instagramData,
+                message: "Please provide either a video file or a video URL, not both.",
+            });
+            return;
+        }
+
+        if (!accountId) {
+            res.render("upload_page", {
+                uploaded: false,
+                error: true,
+                accounts: req.session.instagramData,
+                message: "No account has been selected.",
+            });
+            return;
+        }
+
+        if (err) {
+            res.render("upload_page", {
+                uploaded: false,
+                error: true,
+                accounts: req.session.instagramData,
+                message: `File upload error: ${err.message}`,
+            });
+            return;
+        }
+
+        if (!videoFile && !videoUrl) {
+            res.render("upload_page", {
+                uploaded: false,
+                error: true,
+                accounts: req.session.instagramData,
+                message: "Please provide a video file or a video URL.",
+            });
+            return;
+        }
+
+        const product = isStories !== undefined ? "STORIES" : "REELS";
+
+        try {
+            let containerId;
+
+            if (videoFile) {
+                // Resumable upload path: create container, then upload binary
+                const createContainerUri = buildGraphAPIURL(`${accountId}/media`, {
+                    media_type: product,
+                    upload_type: 'resumable',
+                    caption,
+                    cover_url: coverUrl,
+                    thumb_offset: thumbOffset,
+                    location_id: locationId,
+                }, req.session.userToken);
+
+                const containerResponse = await axios.post(createContainerUri);
+                containerId = containerResponse.data.id;
+                const uploadUri = containerResponse.data.uri;
+
+                const filePath = path.join(__dirname, videoFile.path);
+                const fileData = fs.readFileSync(filePath);
+                const fileSize = videoFile.size;
+
+                Object.assign(req.session, { accountId, containerId });
+
+                // Respond immediately so the UI can show upload progress
+                res.render("upload_page", {
+                    uploaded: true,
+                    accountId,
+                    containerId,
+                    message: `${product.toLowerCase()} container created on IG UserID #${accountId} at Container ID #${containerId}. Uploading video...`,
+                });
+
+                // Upload binary in the background — status is tracked via /asyncStatus
+                axios({
+                    method: 'post',
+                    url: uploadUri,
+                    data: fileData,
+                    maxBodyLength: Infinity,
+                    headers: {
+                        'Authorization': `OAuth ${req.session.userToken}`,
+                        'offset': 0,
+                        'file_size': fileSize,
+                    },
+                }).then(() => {
+                    fs.unlinkSync(filePath);
+                }).catch(() => {
+                    fs.unlink(filePath, () => {});
+                });
+
+                return;
+            } else {
+                // URL-based upload path: create container with video_url
+                const uploadVideoUri = buildGraphAPIURL(`${accountId}/media`, {
+                    media_type: product,
+                    video_url: videoUrl,
+                    caption,
+                    cover_url: coverUrl,
+                    thumb_offset: thumbOffset,
+                    location_id: locationId,
+                }, req.session.userToken);
+
+                const uploadResponse = await axios.post(uploadVideoUri);
+                containerId = uploadResponse.data.id;
+            }
+
+            Object.assign(req.session, { accountId, containerId });
+
+            res.render("upload_page", {
+                uploaded: true,
+                accountId,
+                containerId,
+                message: `${product.toLowerCase()} uploaded successfully on IG UserID #${accountId} at Container ID #${containerId}. You can Publish now.`,
+            });
+        } catch (e) {
+            const errorDetail = e.response?.data?.error || e.message || e;
+            res.render("upload_page", {
+                uploaded: false,
+                error: true,
+                accounts: req.session.instagramData,
+                message: `Error during upload. [Selected account id - ${accountId}]: ${errorDetail}`,
+            });
+        }
+    });
 });
 
 app.post("/publishReels", async function (req, res) {
@@ -302,6 +423,21 @@ app.post("/publishReels", async function (req, res) {
             error: true,
             message: `Reel Upload Failed for IG UserID #${accountId} !`
         });
+    }
+});
+
+app.get('/asyncStatus', async function (req, res) {
+    const { containerId } = req.session;
+    const checkStatusUri = buildGraphAPIURL(`${containerId}`, {
+        fields: 'id,status,status_code,video_status',
+    }, req.session.userToken);
+
+    try {
+        const statusResponse = await axios.get(checkStatusUri);
+        res.send(statusResponse.data);
+    } catch (error) {
+        const errorDetail = error.response?.data?.error || error.message || 'Unknown error';
+        res.send({ status_code: 'ERROR', status: `API error: ${JSON.stringify(errorDetail)}`, container_id: containerId });
     }
 });
 

--- a/insta_reels_publishing_api_sample/upload_page.pug
+++ b/insta_reels_publishing_api_sample/upload_page.pug
@@ -14,7 +14,7 @@ html
         .canvas
             - let accountsArr = accounts ?? [];
             if (accountsArr.length > 0)
-                form(action='/uploadReels' name="uploadForm" id="uploadForm" method='POST')
+                form(action='/uploadReels' name="uploadForm" id="uploadForm" method='POST' enctype="multipart/form-data")
                     b Select an Instagram Professional Account to publish reel to
                     div(class='radio-group')
                         each account, index in accountsArr
@@ -25,6 +25,10 @@ html
                     div(class='checkbox-group')
                         input(type="checkbox" id="isStories" placeholder="Upload as Stories" name="isStories")
                         label(for="isStories") Make the request for Stories
+                    br
+                    input(id='file-upload' type='file' name='videoFile' accept='video/*')
+                    br
+                    b or
                     br
                     input(type="text" placeholder="Enter video url" name="videoUrl")
                     input(type="text" placeholder="Enter caption (optional)" name="caption")
@@ -71,8 +75,17 @@ html
                     .alert
                         span.closebtn(onclick="this.parentElement.style.display='none';") &times;
                         |   #{message}
+                    div(class="progress" id="progress")
+                        strong(id="upload-status") Upload Status: checking...
+                        |
+                        span(id="loading-indicator" style="display:inline") &#8987;
+                    div(id="status-error" style="display:none;margin:10px;padding:10px;background-color:#a51414;color:white")
+                    details(style="margin:10px;text-align:left")
+                        summary(style="cursor:pointer;text-align:center") Show API Response
+                        pre(id="raw-response" style="background:#f4f4f4;padding:10px;overflow-x:auto;font-size:12px;max-height:300px") Waiting for first poll...
+                    script(src="asyncStatusRefresh.js")
                     form(method='POST', action='/publishReels')
-                        input(type='submit', name='publishReels', value='Publish', onclick="this.form.submit(); this.disabled = true;")
+                        input(id='publish-button' type='submit', name='publishReels', value='Waiting for upload to finish...', disabled=true, onclick="this.form.submit(); this.disabled = true;")
                 if(published)
                     if(message.length > 0)
                         each msg in message


### PR DESCRIPTION
## Summary

- Adds local video file upload support to the Instagram sample app using the [Resumable Upload API](https://developers.facebook.com/docs/instagram-api/guides/content-publishing) (`upload_type=resumable`), alongside the existing URL-based upload flow
- Wires up multer (already listed as a dependency) for local file handling with video format validation and a 1GB size limit matching the IG Reels spec
- Adds real-time upload status polling via a new `asyncStatusRefresh.js` client-side script and `/asyncStatus` server endpoint, displaying upload phase, bytes transferred, processing phase, and detailed errors from the `video_status` API field
- The binary upload to `rupload.facebook.com` runs in the background after the page renders, so users see live progress instead of a frozen page

## Changes

### `index.js`
- Added multer import and disk storage configuration (destination: `local/store/videos`, 1GB limit, video format filter)
- Restructured `POST /uploadReels` to support two paths:
  - **File upload**: creates container with `upload_type=resumable`, renders the page immediately, then uploads binary to the returned `uri` in the background (fire-and-forget)
  - **URL upload**: unchanged from the original flow
- Added input validation (both/neither file+URL, no account selected, multer errors)
- Added `GET /asyncStatus` endpoint that returns the full container status including `video_status` (uploading/processing phases and errors)

### `upload_page.pug`
- Added `enctype="multipart/form-data"` to the upload form
- Added file input (`accept='video/*'`) with "or" separator before the URL text input
- Added status polling UI: upload status display with color-coded status, loading indicator, error box, collapsible raw API response section, and a disabled Publish button that enables when status reaches `FINISHED`

### `asyncStatusRefresh.js` (new file)
- Client-side polling script that hits `/asyncStatus` every 3.5 seconds
- Displays `status_code`, uploading phase status + bytes transferred, and processing phase status
- Stops polling on `FINISHED`, `ERROR`, `EXPIRED`, or phase-level errors
- Shows detailed error messages from `video_status.uploading_phase.errors[]` and `processing_phase.errors[]`
- Enables the Publish button when upload is complete

### `README.md` / `CHANGELOG.md`
- Documented the new Resumable Upload feature and added a v3.0.0 changelog entry

## Test plan

- [ ] Start the app (`npm start`), log in, verify the upload form shows both a file input and URL text input
- [ ] Upload a video via URL — confirm existing flow works unchanged
- [ ] Upload a local video file — confirm the page shows live status polling (upload phase, bytes transferred, processing phase)
- [ ] Verify the Publish button is disabled until status reaches `FINISHED`, then enables
- [ ] Upload an invalid file format — confirm multer rejects it with an error message
- [ ] Submit with both file and URL — confirm validation error
- [ ] Upload a video that will fail processing (e.g., wrong aspect ratio) — confirm error details are displayed and polling stops
- [ ] Expand "Show API Response" to verify raw JSON is displayed correctly
